### PR TITLE
fix children type

### DIFF
--- a/dist/types/interfaces/gridComponent.d.ts
+++ b/dist/types/interfaces/gridComponent.d.ts
@@ -1,11 +1,11 @@
-import type { ReactElement, Key } from 'react';
+import type { ReactNode, Key } from 'react';
 import type { DraggerEvent } from '../muuri';
 import type { DecoratedGrid } from './grid';
 import type { DecoratedItem } from './item';
 import type { GridProps } from './muuriComponent';
 export interface ReactGridProps {
     /** The items to render. */
-    children?: ReactElement[];
+    children?: ReactNode;
     /** The attributes of the grid element. */
     gridProps?: object;
     /** The filter predicate of th grid. */

--- a/src/interfaces/gridComponent.ts
+++ b/src/interfaces/gridComponent.ts
@@ -1,4 +1,4 @@
-import type {ReactElement, Key} from 'react';
+import type {ReactNode, Key} from 'react';
 import type {DraggerEvent} from '../muuri'; // eslint-disable-line
 import type {DecoratedGrid} from './grid';
 import type {DecoratedItem} from './item';
@@ -7,7 +7,7 @@ import type {GridProps} from './muuriComponent';
 // Grid props.
 export interface ReactGridProps {
   /** The items to render. */
-  children?: ReactElement[];
+  children?: ReactNode;
   /** The attributes of the grid element. */
   gridProps?: object;
   /** The filter predicate of th grid. */


### PR DESCRIPTION
`children` may be of type ReactNode which includes `ReactElement` as well as `ReactElement[]`